### PR TITLE
https for git clone from github works better

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Used to start new applications which use Searchkit. Based off the popular create
 
 ##  Install instructions
 
-- git clone git@github.com:searchkit/searchkit-starter-app.git
+- git clone https://github.com/searchkit/searchkit-starter-app.git
 - cd searchkit-starter-app
 - yarn
 - npm start


### PR DESCRIPTION
Cloning into 'searchkit-starter-app'...
ssh: connect to host github.com port 22: Connection timed out
fatal: Could not read from remote repository.